### PR TITLE
feat(deployment): add ignorefileandlogfilepath as a serviced dacdeployoptions value

### DIFF
--- a/src/DacTools.Deployment.Core/Arguments.cs
+++ b/src/DacTools.Deployment.Core/Arguments.cs
@@ -35,6 +35,7 @@ namespace DacTools.Deployment.Core
                 DropIndexesNotInSource = false,
                 IgnorePermissions = true,
                 IgnoreRoleMembership = true,
+                IgnoreFileAndLogFilePath = true,
                 GenerateSmartDefaults = true,
                 DropObjectsNotInSource = true,
                 DoNotDropObjectTypes = new[]

--- a/src/DacTools.Deployment/ArgumentParser.cs
+++ b/src/DacTools.Deployment/ArgumentParser.cs
@@ -157,6 +157,12 @@ namespace DacTools.Deployment
                     continue;
                 }
 
+                if (name.IsParameter("IgnoreFileAndLogFilePath"))
+                {
+                    arguments.DacDeployOptions.IgnoreFileAndLogFilePath = ParseBooleanParameter(values, true);
+                    continue;
+                }
+
                 if (name.IsParameter("GenerateSmartDefaults"))
                 {
                     arguments.DacDeployOptions.GenerateSmartDefaults = ParseBooleanParameter(values, true);


### PR DESCRIPTION
Add `IgnoreFileAndLogFilePath` as an available `DacDeployOptions` value, defaults to true.